### PR TITLE
fix: correct three bugs in feed.js

### DIFF
--- a/public/src/js/feed.js
+++ b/public/src/js/feed.js
@@ -81,7 +81,7 @@ function initializeMedia() {
       }
 
       return new Promise((resolve, reject) =>
-        getUserMedia.call(navigator, contrainers, resolve, reject)
+        getUserMedia.call(navigator, constraints, resolve, reject)
       );
     };
   }
@@ -106,8 +106,8 @@ captureButton.addEventListener("click", evt => {
     videoPlayer,
     0,
     0,
-    canvas.width,
-    videoPlayer.videoHeight / (videoPlayer.videoWidth / canvas.width) // maintain aspect ratio
+    canvasElement.width,
+    videoPlayer.videoHeight / (videoPlayer.videoWidth / canvasElement.width) // maintain aspect ratio
   );
   videoPlayer.srcObject.getVideoTracks().forEach(track => track.stop());
   picture = dataURItoBlob(canvasElement.toDataURL());
@@ -270,7 +270,6 @@ function submitPost() {
   postData.append("file", picture, id + ".png");
   postData.append("rawLocationLat", fetchedLocation.lat);
   postData.append("rawLocationLng", fetchedLocation.lng);
-  postData.append("file", picture, id + ".png");
   console.log(`[App] Submitting post data`, postData);
 
   return fetch(


### PR DESCRIPTION
## Summary

Three silent bugs in `public/src/js/feed.js`, all introduced during the original development and never caught due to the lack of tests.

- **`contrainers` typo** — `getUserMedia` polyfill passed the wrong variable name to the legacy `webkitGetUserMedia`/`mozGetUserMedia` API, causing a `ReferenceError` on browsers that don't natively support `navigator.mediaDevices.getUserMedia`
- **`canvas` → `canvasElement`** — the capture button's click handler referenced a bare `canvas` global that doesn't exist; should be `canvasElement` (the declared `const` at the top of the file). Would throw `ReferenceError: canvas is not defined` on every photo capture attempt
- **Duplicate file append** — `submitPost()` called `postData.append("file", picture, ...)` twice, sending the image twice in the multipart upload

## Test plan

- [ ] Open the create post modal (FAB button) — no console errors
- [ ] App loads and feed renders without errors
- [ ] (Manual) On a browser without `mediaDevices` support, camera polyfill no longer throws `ReferenceError`
- [ ] (Manual) Clicking CAPTURE no longer throws `ReferenceError: canvas is not defined`
- [ ] (Manual) Submitting a post sends the image only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)