### PR TITLE
fix: normalize EXIF orientation for image picker uploads (fixes #2)

### DIFF
--- a/public/src/js/feed.js
+++ b/public/src/js/feed.js
@@ -113,8 +113,21 @@ captureButton.addEventListener("click", evt => {
   picture = dataURItoBlob(canvasElement.toDataURL());
 });
 
-imagePicker.addEventListener("change", event => {
-  picture = event.target.files[0];
+imagePicker.addEventListener("change", async event => {
+  const file = event.target.files[0];
+  if (!file) return;
+  // CSS background-image ignores EXIF orientation, so bake the rotation into
+  // the pixels now by drawing through a canvas with imageOrientation applied.
+  try {
+    const bitmap = await createImageBitmap(file, { imageOrientation: "from-image" });
+    const offscreen = document.createElement("canvas");
+    offscreen.width = bitmap.width;
+    offscreen.height = bitmap.height;
+    offscreen.getContext("2d").drawImage(bitmap, 0, 0);
+    offscreen.toBlob(blob => { picture = blob; }, file.type || "image/jpeg", 0.92);
+  } catch {
+    picture = file;
+  }
 });
 
 /**


### PR DESCRIPTION
## Summary

Closes #2.

Photos taken on mobile devices store the correct rotation as EXIF metadata but save pixels in the camera sensor's native (often landscape) orientation. CSS `background-image` — used to display feed cards — ignores EXIF entirely, so portrait shots appeared rotated 90°.

**Fix:** when a file is selected via the image picker, draw it through an offscreen `<canvas>` using `createImageBitmap(file, { imageOrientation: 'from-image' })`. This applies the EXIF rotation to the pixel data before upload, so the stored image is always correctly oriented regardless of how the client renders it. Falls back to using the raw `File` if `createImageBitmap` is unavailable.

The camera capture path (video → canvas) is unaffected — the live video stream already reflects the correct orientation.

## Test plan

- [ ] Pick a photo taken in portrait orientation on a mobile device — should display upright in the feed after posting
- [ ] Pick a landscape photo — should display correctly
- [ ] App loads without console errors
- [ ] File picker still assigns `picture` before form submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)