### PR TITLE
feat: replace hardcoded location with Nominatim reverse geocoding

### DIFF
--- a/public/src/js/feed.js
+++ b/public/src/js/feed.js
@@ -25,15 +25,28 @@ locationButton.addEventListener("click", () => {
   locationLoader.style.display = "block";
 
   navigator.geolocation.getCurrentPosition(
-    pos => {
-      locationButton.style.display = "inline";
-      locationLoader.style.display = "none";
+    async pos => {
       fetchedLocation = {
         lat: pos.coords.latitude,
         lng: pos.coords.longitude
       };
-      // TODO: replace with real reverse geocoding (PR 3)
-      locationInput.value = "In Alexandria, VA";
+      try {
+        const res = await fetch(
+          `https://nominatim.openstreetmap.org/reverse?format=json&lat=${fetchedLocation.lat}&lon=${fetchedLocation.lng}`,
+          { headers: { "Accept-Language": navigator.language || "en" } }
+        );
+        if (res.ok) {
+          const data = await res.json();
+          const addr = data.address || {};
+          const place = addr.city || addr.town || addr.village || addr.suburb || addr.county || "";
+          const region = addr.state || addr.country || "";
+          locationInput.value = [place, region].filter(Boolean).join(", ");
+        }
+      } catch {
+        // geocoding failed — leave input empty so user can type manually
+      }
+      locationButton.style.display = "inline";
+      locationLoader.style.display = "none";
       document.querySelector("#manual-location").classList.add("is-focused");
     },
     () => {


### PR DESCRIPTION
## Summary

Replaces the `"In Alexandria, VA"` placeholder string with a real reverse geocoding call to the [OpenStreetMap Nominatim API](https://nominatim.openstreetmap.org/) (free, no API key required).

## How it works

1. User taps GET LOCATION — spinner appears, GPS acquisition begins
2. On GPS success, a `fetch` to `nominatim.openstreetmap.org/reverse` is made with the lat/lng and the browser's `Accept-Language` for localised results
3. The location field is populated from the response: `city/town/village/suburb/county + state/country`
4. Spinner hides only after both GPS **and** geocoding complete (UX improvement over the original)
5. On geocoding failure the input is left empty so the user can type manually — GPS coordinates are still captured for the post

## Before / After

| Before | After |
|---|---|
| Always filled `"In Alexandria, VA"` | Real place name based on device location |
| Spinner hid on GPS success | Spinner stays until geocoding also finishes |

## Test plan

- [ ] Tap GET LOCATION — spinner stays visible during geocoding
- [ ] Location field populates with a real place name
- [ ] Denying GPS permission shows the manual-entry alert as before
- [ ] If Nominatim is unreachable, input is left empty (no error thrown)
- [ ] No console errors on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)