### PR TITLE
feat: migrate src/js to TypeScript

### DIFF
--- a/help/index.html
+++ b/help/index.html
@@ -93,7 +93,7 @@
   </div>
 
   <script defer src="/src/js/material.min.js"></script>
-  <script type="module" src="/src/js/app.js"></script>
+  <script type="module" src="/src/js/app.ts"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -118,8 +118,8 @@
     </div>
   </div>
   <script defer src="/src/js/material.min.js"></script>
-  <script type="module" src="/src/js/app.js"></script>
-  <script type="module" src="/src/js/feed.js"></script>
+  <script type="module" src="/src/js/app.ts"></script>
+  <script type="module" src="/src/js/feed.ts"></script>
 </body>
 
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "fake-indexeddb": "^6.2.5",
         "jsdom": "^29.1.1",
         "remotedebug-ios-webkit-adapter": "^0.2.2",
+        "typescript": "^6.0.3",
         "vite": "^8.0.14",
         "vite-plugin-pwa": "^1.3.0",
         "vitest": "^4.1.7",
@@ -7573,6 +7574,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/ultron": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "vite",
     "remote-ios": "remotedebug_ios_webkit_adapter --port=9000",
     "test": "vitest run",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "pwa",
@@ -25,6 +26,7 @@
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.1.1",
     "remotedebug-ios-webkit-adapter": "^0.2.2",
+    "typescript": "^6.0.3",
     "vite": "^8.0.14",
     "vite-plugin-pwa": "^1.3.0",
     "vitest": "^4.1.7",

--- a/src/js/app.ts
+++ b/src/js/app.ts
@@ -1,13 +1,25 @@
 import { urlBase64ToUint8Array } from './utils.js';
 
-window.deferredPrompt;
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+declare global {
+  interface Window {
+    deferredPrompt: BeforeInstallPromptEvent | null;
+  }
+}
+
+window.deferredPrompt = null;
 const enableNotificationsButtons = document.querySelectorAll(
   '.enable-notifications'
 );
 
 async function displayConfirmNotification() {
   const title = 'Successfully subscribed';
-  const options = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const options: any = {
     body: 'Awesome!',
     icon: '/src/images/icons/app-icon-96x96.png',
     image: '/src/images/sf-boat.jpg',
@@ -49,7 +61,7 @@ async function configurePushSub() {
       'BH1lo34DNnIy__lc7nzIMyDr2tBmGqqoRThEoRzoj2GehQ8Yg4_X2JvkHfX06Vbqxjys6I0fz2mGLu2nkC45S5o';
     const newSub = await sw.pushManager.subscribe({
       userVisibleOnly: true,
-      applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY)
+      applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY).buffer as ArrayBuffer
     });
     const res = await fetch(
       'https://pwagram-439bb.firebaseio.com/subscriptions.json',
@@ -72,7 +84,7 @@ async function askForNotificationPermission() {
   const permission = await Notification.requestPermission();
   if (permission === 'granted') {
     enableNotificationsButtons.forEach(btn => {
-      btn.style.display = 'inline-block';
+      (btn as HTMLElement).style.display = 'inline-block';
     });
     configurePushSub();
   }
@@ -83,19 +95,19 @@ if ('serviceWorker' in navigator) {
 
   window.addEventListener('beforeinstallprompt', event => {
     event.preventDefault();
-    window.deferredPrompt = event;
+    window.deferredPrompt = event as BeforeInstallPromptEvent;
     return false;
   });
 
   if ('SyncManager' in window) {
     navigator.serviceWorker.ready
-      .then(sw => sw.sync.register('sync-new-posts'))
+      .then(sw => (sw as unknown as { sync: { register(tag: string): Promise<void> } }).sync.register('sync-new-posts'))
       .catch(() => {});
   }
 
   if ('Notification' in window && Notification.permission === 'default') {
     enableNotificationsButtons.forEach(btn => {
-      btn.style.display = 'inline-block';
+      (btn as HTMLElement).style.display = 'inline-block';
       btn.addEventListener('click', askForNotificationPermission);
     });
   }

--- a/src/js/feed.ts
+++ b/src/js/feed.ts
@@ -1,23 +1,31 @@
 import { getItems, writeItem, dataURItoBlob } from './utils.js';
 
-const shareImageButton = document.querySelector('#share-image-button');
-const createPostArea = document.querySelector('#create-post');
+declare const componentHandler: { upgradeElement: (el: Element) => void };
+
+declare global {
+  interface Window {
+    SyncManager?: unknown;
+  }
+}
+
+const shareImageButton = document.querySelector('#share-image-button') as HTMLButtonElement;
+const createPostArea = document.querySelector('#create-post') as HTMLDivElement;
 const closeCreatePostModalButton = document.querySelector(
   '#close-create-post-modal-btn'
-);
-const sharedMomentsArea = document.querySelector('#shared-moments');
-const form = document.querySelector('form');
-const titleInput = document.querySelector('#title');
-const locationInput = document.querySelector('#location');
-const videoPlayer = document.querySelector('#player');
-const canvasElement = document.querySelector('#canvas');
-const captureButton = document.querySelector('#capture-btn');
-const imagePicker = document.querySelector('#image-picker');
-const imagePickerArea = document.querySelector('#pick-image');
-let picture;
+) as HTMLButtonElement;
+const sharedMomentsArea = document.querySelector('#shared-moments') as HTMLDivElement;
+const form = document.querySelector('form') as HTMLFormElement;
+const titleInput = document.querySelector('#title') as HTMLInputElement;
+const locationInput = document.querySelector('#location') as HTMLInputElement;
+const videoPlayer = document.querySelector('#player') as HTMLVideoElement;
+const canvasElement = document.querySelector('#canvas') as HTMLCanvasElement;
+const captureButton = document.querySelector('#capture-btn') as HTMLButtonElement;
+const imagePicker = document.querySelector('#image-picker') as HTMLInputElement;
+const imagePickerArea = document.querySelector('#pick-image') as HTMLDivElement;
+let picture: Blob | undefined;
 
-const locationButton = document.querySelector('#location-btn');
-const locationLoader = document.querySelector('#location-loader');
+const locationButton = document.querySelector('#location-btn') as HTMLButtonElement;
+const locationLoader = document.querySelector('#location-loader') as HTMLDivElement;
 let fetchedLocation = { lat: 0, lng: 0 };
 
 locationButton.addEventListener('click', () => {
@@ -49,7 +57,7 @@ locationButton.addEventListener('click', () => {
       }
       locationButton.style.display = 'inline';
       locationLoader.style.display = 'none';
-      document.querySelector('#manual-location').classList.add('is-focused');
+      (document.querySelector('#manual-location') as HTMLElement).classList.add('is-focused');
     },
     () => {
       locationButton.style.display = 'inline';
@@ -72,19 +80,19 @@ function initializeLocation() {
  */
 async function initializeMedia() {
   if (!('mediaDevices' in navigator)) {
-    navigator.mediaDevices = {};
+    (navigator as unknown as { mediaDevices: MediaDevices }).mediaDevices = {} as MediaDevices;
   }
 
   if (!('getUserMedia' in navigator.mediaDevices)) {
-    navigator.mediaDevices.getUserMedia = constraints => {
+    (navigator.mediaDevices as any).getUserMedia = (constraints: MediaStreamConstraints) => {
       const getUserMedia =
-        navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
+        (navigator as any).webkitGetUserMedia || (navigator as any).mozGetUserMedia;
 
       if (!getUserMedia) {
         return Promise.reject(new Error('getUserMedia is not implemented'));
       }
 
-      return new Promise((resolve, reject) =>
+      return new Promise<MediaStream>((resolve, reject) =>
         getUserMedia.call(navigator, constraints, resolve, reject)
       );
     };
@@ -103,7 +111,7 @@ captureButton.addEventListener('click', () => {
   canvasElement.style.display = 'block';
   videoPlayer.style.display = 'none';
   captureButton.style.display = 'none';
-  const context = canvasElement.getContext('2d');
+  const context = canvasElement.getContext('2d')!;
   context.drawImage(
     videoPlayer,
     0,
@@ -111,12 +119,12 @@ captureButton.addEventListener('click', () => {
     canvasElement.width,
     videoPlayer.videoHeight / (videoPlayer.videoWidth / canvasElement.width)
   );
-  videoPlayer.srcObject.getVideoTracks().forEach(track => track.stop());
+  (videoPlayer.srcObject as MediaStream).getVideoTracks().forEach(track => track.stop());
   picture = dataURItoBlob(canvasElement.toDataURL());
 });
 
 imagePicker.addEventListener('change', async event => {
-  const file = event.target.files[0];
+  const file = (event.target as HTMLInputElement).files![0];
   if (!file) return;
   // CSS background-image ignores EXIF orientation, so bake the rotation into
   // the pixels now by drawing through a canvas with imageOrientation applied.
@@ -125,8 +133,8 @@ imagePicker.addEventListener('change', async event => {
     const offscreen = document.createElement('canvas');
     offscreen.width = bitmap.width;
     offscreen.height = bitmap.height;
-    offscreen.getContext('2d').drawImage(bitmap, 0, 0);
-    offscreen.toBlob(blob => { picture = blob; }, file.type || 'image/jpeg', 0.92);
+    offscreen.getContext('2d')!.drawImage(bitmap, 0, 0);
+    offscreen.toBlob(blob => { picture = blob ?? undefined; }, file.type || 'image/jpeg', 0.92);
   } catch {
     picture = file;
   }
@@ -154,7 +162,7 @@ function closeCreatePostModal() {
   locationButton.style.display = 'inline';
   locationLoader.style.display = 'none';
   if (videoPlayer.srcObject) {
-    videoPlayer.srcObject.getVideoTracks().forEach(track => track.stop());
+    (videoPlayer.srcObject as MediaStream).getVideoTracks().forEach(track => track.stop());
   }
   setTimeout(() => {
     createPostArea.style.transform = 'translateY(100vh)';
@@ -164,11 +172,17 @@ closeCreatePostModalButton.addEventListener('click', closeCreatePostModal);
 
 function clearCards() {
   while (sharedMomentsArea.hasChildNodes()) {
-    sharedMomentsArea.removeChild(sharedMomentsArea.lastChild);
+    sharedMomentsArea.removeChild(sharedMomentsArea.lastChild!);
   }
 }
 
-function createCard(card) {
+interface PostCard {
+  image: string;
+  title: string;
+  location: string;
+}
+
+function createCard(card: PostCard) {
   const cardWrapper = document.createElement('div');
   cardWrapper.className = 'shared-moment-card mdl-card mdl-shadow--2dp';
   const cardTitle = document.createElement('div');
@@ -192,7 +206,7 @@ function createCard(card) {
   sharedMomentsArea.appendChild(cardWrapper);
 }
 
-function createCards(cards) {
+function createCards(cards: PostCard[]) {
   cards.forEach(card => createCard(card));
 }
 
@@ -204,7 +218,7 @@ function loadDataAndUpdate() {
 
   fetch(url)
     .then(res => (res.ok ? res.json() : null))
-    .then(data => {
+    .then((data: Record<string, PostCard> | null) => {
       if (!data) return;
       networkDataReceived = true;
       clearCards();
@@ -216,7 +230,7 @@ function loadDataAndUpdate() {
     getItems('posts').then(posts => {
       if (!networkDataReceived) {
         clearCards();
-        createCards(posts);
+        createCards(posts as PostCard[]);
       }
     });
   }
@@ -230,9 +244,9 @@ async function submitPost() {
   postData.append('id', id);
   postData.append('title', titleInput.value);
   postData.append('location', locationInput.value);
-  postData.append('file', picture, id + '.png');
-  postData.append('rawLocationLat', fetchedLocation.lat);
-  postData.append('rawLocationLng', fetchedLocation.lng);
+  postData.append('file', picture!, id + '.png');
+  postData.append('rawLocationLat', String(fetchedLocation.lat));
+  postData.append('rawLocationLng', String(fetchedLocation.lng));
 
   try {
     await fetch(
@@ -257,9 +271,9 @@ async function submitPostViaSyncManager() {
   };
   try {
     await writeItem('sync-posts', post);
-    await sw.sync.register('sync-new-posts');
+    await (sw as any).sync.register('sync-new-posts');
     const snackbarContainer = document.querySelector('#confirmation-toast');
-    snackbarContainer.MaterialSnackbar.showSnackbar({
+    (snackbarContainer as any).MaterialSnackbar.showSnackbar({
       message: 'Your Post was saved for syncing!'
     });
   } catch {
@@ -290,8 +304,8 @@ form.addEventListener('submit', async evt => {
 
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.addEventListener('message', event => {
-    event.ports[0].postMessage('ACK');
-    if (event.data === 'refresh') {
+    (event as MessageEvent).ports[0].postMessage('ACK');
+    if ((event as MessageEvent).data === 'refresh') {
       loadDataAndUpdate();
     }
   });

--- a/src/js/utils.test.ts
+++ b/src/js/utils.test.ts
@@ -1,4 +1,4 @@
-// fake-indexeddb/auto MUST be imported before utils.js so it patches
+// fake-indexeddb/auto MUST be imported before utils.ts so it patches
 // globalThis.indexedDB before the module-level dbPromise is created.
 import 'fake-indexeddb/auto';
 
@@ -91,9 +91,9 @@ describe('IDB CRUD (posts store)', () => {
 
   it('getItem retrieves a single record by id', async () => {
     await writeItem('posts', { id: '42', title: 'Beta', location: 'LA' });
-    const item = await getItem('posts', '42');
+    const item = await getItem('posts', '42') as { title: string } | undefined;
     expect(item).toBeDefined();
-    expect(item.title).toBe('Beta');
+    expect(item!.title).toBe('Beta');
   });
 
   it('getItem returns undefined for a non-existent id', async () => {
@@ -107,7 +107,7 @@ describe('IDB CRUD (posts store)', () => {
     await deleteItem('posts', 'b');
     const items = await getItems('posts');
     expect(items).toHaveLength(1);
-    expect(items[0].id).toBe('a');
+    expect((items[0] as { id: string }).id).toBe('a');
   });
 
   it('deleteItems clears all records', async () => {

--- a/src/js/utils.ts
+++ b/src/js/utils.ts
@@ -11,27 +11,27 @@ const dbPromise = openDB('posts-store', 1, {
   }
 });
 
-export async function writeItem(storeName, item) {
+export async function writeItem(storeName: string, item: unknown): Promise<IDBValidKey> {
   return (await dbPromise).put(storeName, item);
 }
 
-export async function getItems(storeName) {
+export async function getItems(storeName: string): Promise<unknown[]> {
   return (await dbPromise).getAll(storeName);
 }
 
-export async function getItem(storeName, id) {
+export async function getItem(storeName: string, id: IDBKeyRange | IDBValidKey): Promise<unknown> {
   return (await dbPromise).get(storeName, id);
 }
 
-export async function deleteItems(storeName) {
+export async function deleteItems(storeName: string): Promise<void> {
   return (await dbPromise).clear(storeName);
 }
 
-export async function deleteItem(storeName, id) {
+export async function deleteItem(storeName: string, id: IDBKeyRange | IDBValidKey): Promise<void> {
   return (await dbPromise).delete(storeName, id);
 }
 
-export function urlBase64ToUint8Array(base64String) {
+export function urlBase64ToUint8Array(base64String: string): Uint8Array {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
   const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
   const rawData = atob(base64);
@@ -42,7 +42,7 @@ export function urlBase64ToUint8Array(base64String) {
   return outputArray;
 }
 
-export function dataURItoBlob(dataURI) {
+export function dataURItoBlob(dataURI: string): Blob {
   const byteString = atob(dataURI.split(',')[1]);
   const mimeString = dataURI.split(',')[0].split(':')[1].split(';')[0];
   const ab = new ArrayBuffer(byteString.length);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/js/**/*.ts", "e2e/**/*.ts", "*.config.ts"],
+  "exclude": ["src/js/**/*.test.ts"]
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,6 +3,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    exclude: ['**/node_modules/**', 'e2e/**'],
+    exclude: ['**/node_modules/**', 'e2e/**', '**/*.test.js'],
   },
 });


### PR DESCRIPTION
## Summary

- Renames `src/js/utils.js`, `app.js`, `feed.js`, and `utils.test.js` to `.ts`
- Adds `tsconfig.json` with `strict: true`, `target: ES2020`, `moduleResolution: bundler`
- Adds `npm run typecheck` script (`tsc --noEmit`)
- Updates `index.html` / `help/index.html` script tags to `.ts` extensions (Vite resolves these transparently)

## Type coverage highlights

**`utils.ts`** — explicit parameter and return types on all five IDB helpers and both pure functions

**`app.ts`**
- Declares `BeforeInstallPromptEvent` interface (absent from TS DOM lib)
- Augments `Window` with `deferredPrompt: BeforeInstallPromptEvent | null`

**`feed.ts`**
- Declares `componentHandler` global (MDL loaded via script tag)
- All `document.querySelector` results cast to concrete element types (`HTMLButtonElement`, `HTMLInputElement`, `HTMLVideoElement`, `HTMLCanvasElement`, etc.)
- `PostCard` interface for feed data shape
- Vendor-prefixed `getUserMedia` via `(navigator as any)`
- `MediaStream` cast for `videoPlayer.srcObject`
- `Window.SyncManager` declared; `sw.sync` cast via `any` (not in TS DOM types)

## Test plan
- [x] `npm run typecheck` → zero errors
- [x] `npm test` → 14 / 14 unit tests pass
- [x] `npx playwright test` → 4 / 4 E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)