### PR TITLE
fix: sanitize multipart upload filename to prevent path traversal

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -33,7 +33,8 @@ function parseMultipart(request) {
 
     busboy.on("file", (name, stream, info) => {
       const { filename, mimeType } = info;
-      const filepath = path.join(os.tmpdir(), filename);
+      const safeFilename = uuidv4() + path.extname(path.basename(filename));
+      const filepath = path.join(os.tmpdir(), safeFilename);
       upload = { file: filepath, type: mimeType };
       const writeStream = fs.createWriteStream(filepath);
       writePromises.push(


### PR DESCRIPTION
## Summary

- Fixes path traversal vulnerability in `storePostData` (closes #16)
- User-supplied `filename` from the multipart upload was passed directly to `path.join(os.tmpdir(), filename)`, allowing traversal sequences like `../../etc/passwd` to write outside the temp directory
- The subsequent `bucket.upload()` call would then push the attacker-controlled path to GCS

## What changed

In `functions/index.js`, replaced the raw `filename` with a UUID + original extension:

```js
// Before
const filepath = path.join(os.tmpdir(), filename);

// After
const safeFilename = uuidv4() + path.extname(path.basename(filename));
const filepath = path.join(os.tmpdir(), safeFilename);
```

`uuidv4` was already imported in the file. `path.basename` strips any directory components before `path.extname` extracts the extension, so neither path segments nor crafted extensions can influence the temp path.

## Reviewer notes

- The original `filename` is no longer used in any path operation — only the extension is preserved (e.g. `.jpg`) to keep content-type hints intact
- GCS destination name comes from `uploadedFile.name`, which will now be the UUID-based name — this is fine since the download URL is constructed from `uploadedFile.name` anyway

🤖 Generated with [Claude Code](https://claude.com/claude-code)