### PR TITLE
chore: use pnpm in playwright webServer command

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   webServer: {
-    command: 'npm run preview -- --host 0.0.0.0',
+    command: 'pnpm preview -- --host 0.0.0.0',
     url: 'http://127.0.0.1:1338',
     reuseExistingServer: true,
   },


### PR DESCRIPTION
## Summary

- Replace `npm run preview -- --host 0.0.0.0` with `pnpm preview -- --host 0.0.0.0` in `playwright.config.js`

Closes #32

## Test plan

- [ ] `playwright.config.js` webServer command uses `pnpm`
- [ ] `pnpm preview` script exists in `package.json`
- [ ] Playwright e2e suite runs without errors launching the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)