### PR TITLE
chore: include test files in TypeScript type checking

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,8 @@
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,
-    "allowArbitraryExtensions": true
+    "allowArbitraryExtensions": true,
+    "types": ["vitest/globals"]
   },
-  "include": ["src/js/**/*.ts", "e2e/**/*.ts", "*.config.ts"],
-  "exclude": ["src/js/**/*.test.ts"]
+  "include": ["src/js/**/*.ts", "e2e/**/*.ts", "*.config.ts"]
 }


### PR DESCRIPTION
## Summary

- Remove `"exclude": ["src/js/**/*.test.ts"]` from `tsconfig.json`
- Add `"types": ["vitest/globals"]` to `compilerOptions` so that `describe`/`it`/`expect`/`beforeEach` globals resolve without error

Previously, `src/js/utils.test.ts` was silently excluded from `tsc`, meaning type errors in tests would only surface at runtime.

Closes #31

## Test plan

- [ ] `tsc --noEmit` passes with zero errors
- [ ] `tsc --noEmit --listFiles` includes `src/js/utils.test.ts`
- [ ] `pnpm test` (vitest) still passes all 14 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)