### PR TITLE
chore: move dbPromise declaration before its first use in sw.js

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -8,6 +8,19 @@ import { openDB } from 'idb';
 // Injected by vite-plugin-pwa at build time ([] in dev)
 precacheAndRoute(self.__WB_MANIFEST);
 
+// ─── IndexedDB ────────────────────────────────────────────────────────────────
+
+const dbPromise = openDB('posts-store', 1, {
+  upgrade(db) {
+    if (!db.objectStoreNames.contains('posts')) {
+      db.createObjectStore('posts', { keyPath: 'id' });
+    }
+    if (!db.objectStoreNames.contains('sync-posts')) {
+      db.createObjectStore('sync-posts', { keyPath: 'id' });
+    }
+  }
+});
+
 // ─── Caching strategies ───────────────────────────────────────────────────────
 
 // Google Fonts — cache first, 1-year TTL
@@ -69,19 +82,6 @@ setCatchHandler(async ({ event }) => {
     return (await matchPrecache('/src/images/failwhale.jpg')) ?? Response.error();
   }
   return Response.error();
-});
-
-// ─── IndexedDB (replaces the legacy idb.js importScripts path) ───────────────
-
-const dbPromise = openDB('posts-store', 1, {
-  upgrade(db) {
-    if (!db.objectStoreNames.contains('posts')) {
-      db.createObjectStore('posts', { keyPath: 'id' });
-    }
-    if (!db.objectStoreNames.contains('sync-posts')) {
-      db.createObjectStore('sync-posts', { keyPath: 'id' });
-    }
-  }
 });
 
 // ─── Background Sync ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Moves the `dbPromise = openDB(...)` declaration from line 76 to immediately after the `precacheAndRoute` call at the top of the file
- The declaration now appears at line 13, before the `registerRoute` callback at line 63 that closes over it

Closes #30

## Test plan

- [ ] `dbPromise` declared before any usage in `src/sw.js`
- [ ] `pnpm build` succeeds (service worker compiles cleanly)
- [ ] `pnpm test` passes all unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)