### PR TITLE
chore: remove dead CDN-assets cache route from service worker

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -24,18 +24,6 @@ registerRoute(
   })
 );
 
-// CDN assets (Material Design Lite) — cache first, 1-year TTL
-registerRoute(
-  ({ url }) => url.origin === 'https://cdnjs.cloudflare.com',
-  new CacheFirst({
-    cacheName: 'cdn-assets',
-    plugins: [
-      new CacheableResponsePlugin({ statuses: [0, 200] }),
-      new ExpirationPlugin({ maxEntries: 20, maxAgeSeconds: 365 * 24 * 60 * 60 })
-    ]
-  })
-);
-
 // Firebase posts — network first; on success, sync result into IDB so the
 // browser-side cache-then-network pattern in feed.js sees fresh data.
 const POSTS_URL = 'https://pwagram-439bb.firebaseio.com/posts.json';


### PR DESCRIPTION
## Summary

- Delete the `registerRoute` block for `cdnjs.cloudflare.com` (Material Design Lite CDN)
- This route was left over from before the Tailwind CSS migration (PR #14) and never matches any request

Closes #26

## Test plan

- [ ] `cdnjs.cloudflare.com` / `cdn-assets` references absent from `src/sw.js`
- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes all unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)