### PR TITLE
pwa: set manifest start_url to "/" instead of "/index.html"

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "PWAGram - Instagram Clone",
   "short_name": "PWAGram",
-  "start_url": "/index.html",
+  "start_url": "/",
   "scope": ".",
   "display": "standalone",
   "background_color": "#fff",


### PR DESCRIPTION
## Summary

- Change `"start_url": "/index.html"` → `"start_url": "/"` in `public/manifest.json`

Using `/index.html` can cause the full `.html` path to appear in the address bar for installed PWAs and can interfere with "Add to Home Screen" prompts on some browsers where the trigger URL (`/`) doesn't match the `start_url`.

Closes #28

## Test plan

- [ ] `public/manifest.json` contains `"start_url": "/"`
- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)