### PR TITLE
a11y: remove user-scalable=no and maximum-scale from viewport meta

### DIFF
--- a/help/index.html
+++ b/help/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Help</title>
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>PWAGram</title>
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">


### PR DESCRIPTION
## Summary

- Remove `user-scalable=no`, `maximum-scale=1.0`, and `minimum-scale=1.0` from the `<meta name="viewport">` tag in both `index.html` and `help/index.html`
- Result: `<meta name="viewport" content="width=device-width, initial-scale=1.0">`

This allows users to pinch-zoom and use browser text resize, satisfying **WCAG 2.1 SC 1.4.4 (Resize text, Level AA)**. The Tailwind responsive layout is unaffected.

Closes #27

## Test plan

- [ ] `index.html` viewport meta no longer contains `user-scalable` or `maximum-scale`
- [ ] `help/index.html` same
- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes all unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)