### PR TITLE
bug: await submitPost() and call clearPostForm() on non-SyncManager path

### DIFF
--- a/src/js/feed.ts
+++ b/src/js/feed.ts
@@ -299,7 +299,8 @@ form.addEventListener('submit', async evt => {
     await submitPostViaSyncManager();
     clearPostForm();
   } else {
-    submitPost();
+    await submitPost();
+    clearPostForm();
   }
 });
 


### PR DESCRIPTION
## Summary

- Add `await` before `submitPost()` in the `else` branch of the form submit handler
- Add the missing `clearPostForm()` call after `submitPost()` resolves

Previously, `submitPost()` was called fire-and-forget: the form was never cleared on the non-SyncManager path, and any rejection escaped silently as an unhandled promise rejection.

Closes #25

## Test plan

- [ ] `src/js/feed.ts` submit handler `else` branch awaits `submitPost()` and calls `clearPostForm()`
- [ ] `tsc --noEmit` passes with zero errors
- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes all unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)