### PR TITLE
bug: require image before form submission to prevent server error

### DIFF
--- a/src/js/feed.ts
+++ b/src/js/feed.ts
@@ -293,6 +293,10 @@ form.addEventListener('submit', async evt => {
     alert('Please enter valid data!');
     return;
   }
+  if (!picture) {
+    alert('Please capture or pick an image!');
+    return;
+  }
   closeCreatePostModal();
 
   if ('serviceWorker' in navigator && 'SyncManager' in window) {


### PR DESCRIPTION
## Summary

- Add `if (!picture)` guard before `closeCreatePostModal()` in the form submit handler
- Shows `alert('Please capture or pick an image!')` and returns early when no image has been captured/selected

Previously, submitting without an image would send `undefined` as the file field, causing the Cloud Function to return a 500 error with no user-facing feedback.

Closes #24

## Test plan

- [ ] Submit handler validates `picture` before calling `closeCreatePostModal()`
- [ ] `tsc --noEmit` passes with zero errors
- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes all unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)