### PR TITLE
bug: guard against null event.data in push handler

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -125,11 +125,12 @@ self.addEventListener('sync', event => {
 
 self.addEventListener('push', event => {
   event.preventDefault();
+  const payload = event.data ? JSON.parse(event.data.text()) : {};
   const {
     title = 'New!',
     content = 'Something new happened!',
     openUrl = '/'
-  } = JSON.parse(event.data.text());
+  } = payload;
   event.waitUntil(
     self.registration.showNotification(title, {
       body: content,


### PR DESCRIPTION
## Summary

- Replace `JSON.parse(event.data.text())` with a null-safe pattern: `event.data ? JSON.parse(event.data.text()) : {}`
- Destructure from `payload` with defaults so a no-payload push still shows a sensible notification

Push servers can legally send a push event with no payload (silent wakeup ping). Previously, `event.data` would be `null` and `.text()` would throw a `TypeError`, silently dropping the notification.

Closes #23

## Test plan

- [ ] Push handler uses `event.data ? JSON.parse(event.data.text()) : {}` guard
- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes all unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)