### PR TITLE
bug: remove event.preventDefault() from push handler

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -112,7 +112,6 @@ self.addEventListener('sync', event => {
 // ─── Push notifications ───────────────────────────────────────────────────────
 
 self.addEventListener('push', event => {
-  event.preventDefault();
   const payload = event.data ? JSON.parse(event.data.text()) : {};
   const {
     title = 'New!',


### PR DESCRIPTION
## Summary

- Remove `event.preventDefault()` from the `push` event listener in `src/sw.js`

`PushEvent` inherits from `ExtendableEvent` → `Event`, so the method exists but has **no effect** on push delivery. It neither suppresses the notification nor cancels anything. Its presence misleads readers into thinking it has a meaningful effect on the push lifecycle.

Closes #36

## Test plan

- [ ] `push` event listener in `src/sw.js` no longer contains `event.preventDefault()`
- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes all unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)