### PR TITLE
bug: guard ports[0] access in service worker message handler

### DIFF
--- a/src/js/feed.ts
+++ b/src/js/feed.ts
@@ -305,8 +305,9 @@ form.addEventListener('submit', async evt => {
 
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.addEventListener('message', event => {
-    (event as MessageEvent).ports[0].postMessage('ACK');
-    if ((event as MessageEvent).data === 'refresh') {
+    const msg = event as MessageEvent;
+    if (msg.ports?.[0]) msg.ports[0].postMessage('ACK');
+    if (msg.data === 'refresh') {
       loadDataAndUpdate();
     }
   });


### PR DESCRIPTION
## Summary

- Replace `(event as MessageEvent).ports[0].postMessage('ACK')` with `if (msg.ports?.[0]) msg.ports[0].postMessage('ACK')`
- Extract `event as MessageEvent` into a local `msg` variable to avoid repeated casts

Without this guard, any `postMessage` to the client without a `MessageChannel` (e.g. `SKIP_WAITING`, DevTools messages, or browser-extension messages) throws `TypeError: Cannot read properties of undefined (reading 'postMessage')`, which silently aborts the entire listener — subsequent `refresh` messages from background sync would never trigger a feed reload.

Closes #34

## Test plan

- [ ] `src/js/feed.ts` message handler uses `msg.ports?.[0]` optional chain
- [ ] `tsc --noEmit` passes with zero errors
- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes all unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)