### PR TITLE
bug: return 400 when multipart upload contains no file

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -68,6 +68,10 @@ exports.storePostData = functions.https.onRequest((request, response) => {
       const uuid = uuidv4();
       const { fields, upload } = await parseMultipart(request);
 
+      if (!upload) {
+        return response.status(400).json({ error: "No file uploaded" });
+      }
+
       const bucket = storage.bucket("pwagram-439bb.appspot.com");
       const [uploadedFile] = await bucket.upload(upload.file, {
         metadata: {


### PR DESCRIPTION
## Summary

- Add `if (!upload) return response.status(400).json({ error: 'No file uploaded' })` before `bucket.upload()` in `storePostData`

Previously, a request with no file part left `upload` as `undefined`, causing `upload.file` to throw `TypeError: Cannot read properties of undefined`, which produced a confusing 500 response.

Closes #21

## Test plan

- [ ] `functions/index.js` guards `upload` before `bucket.upload()`
- [ ] `pnpm test` passes all unit tests (Cloud Function not executed in unit tests — manual verification requires Firebase emulator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)