### PR TITLE
bug: delete temp file after GCS upload to prevent /tmp exhaustion

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -69,14 +69,19 @@ exports.storePostData = functions.https.onRequest((request, response) => {
       const { fields, upload } = await parseMultipart(request);
 
       const bucket = storage.bucket("pwagram-439bb.appspot.com");
-      const [uploadedFile] = await bucket.upload(upload.file, {
-        metadata: {
-          contentType: upload.type,
+      let uploadedFile;
+      try {
+        [uploadedFile] = await bucket.upload(upload.file, {
           metadata: {
-            firebaseStorageDownloadTokens: uuid
+            contentType: upload.type,
+            metadata: {
+              firebaseStorageDownloadTokens: uuid
+            }
           }
-        }
-      });
+        });
+      } finally {
+        fs.unlink(upload.file, () => {});
+      }
 
       const imageUrl =
         `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/` +


### PR DESCRIPTION
## Summary

- Wrap `bucket.upload()` in a `try/finally` block that calls `fs.unlink(upload.file, () => {})` in the `finally` branch
- The unlink is fire-and-forget (callback ignores errors) so it doesn't interfere with the response even if the file was already removed or never written

Cloud Functions share a 512 MB `/tmp` filesystem across warm instances. Without cleanup, each upload permanently consumed space, eventually causing `ENOSPC` errors on busy functions.

Closes #22

## Test plan

- [ ] `functions/index.js` wraps `bucket.upload()` in `try/finally` with `fs.unlink`
- [ ] `pnpm test` passes all unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)