### PR TITLE
chore: call loadDataAndUpdate() directly after submitPost — remove setTimeout

### DIFF
--- a/src/js/feed.ts
+++ b/src/js/feed.ts
@@ -258,7 +258,7 @@ async function submitPost() {
       { method: 'POST', body: postData }
     );
     clearPostForm();
-    setTimeout(() => loadDataAndUpdate(), 1000);
+    loadDataAndUpdate();
   } catch {
     // network unavailable — post will sync on reconnect via Background Sync
   }


### PR DESCRIPTION
## Summary

- Replace `setTimeout(() => loadDataAndUpdate(), 1000)` with a direct `loadDataAndUpdate()` call
- The `await fetch(...)` already awaits the server's 201 response, so the data is persisted when we refresh — no delay needed

The 1-second delay was both too long on fast connections and potentially too short under load.

Closes #33

## Test plan

- [ ] `setTimeout` removed from `submitPost()` in `src/js/feed.ts`
- [ ] `tsc --noEmit` passes with zero errors
- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes all unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)