### PR TITLE
bug: delete sync-post by local post.id instead of server-returned id

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -103,8 +103,7 @@ async function syncNewPosts() {
       postData.append('file', post.picture, `${post.id}.png`);
       const res = await fetch(UPLOAD_POSTS_URL, { method: 'POST', body: postData });
       if (!res.ok) throw new Error(res.statusText);
-      const { id } = await res.json();
-      await db.delete('sync-posts', id);
+      await db.delete('sync-posts', post.id);
     })
   );
   // Notify all open clients to refresh the feed


### PR DESCRIPTION
## Summary

- Replace `const { id } = await res.json(); await db.delete('sync-posts', id)` with `await db.delete('sync-posts', post.id)`
- Remove the `res.json()` parse — the response body is no longer needed

The server echoes back the client-supplied `id` (`fields.id`), so server and local ids happen to match today. But parsing the response body to get back what was sent is fragile: if the server response shape changes or omits the field, `id` would be `undefined`, `db.delete('sync-posts', undefined)` would silently no-op, and the post would be re-uploaded on every future background sync.

Closes #37

## Test plan

- [ ] `syncNewPosts()` deletes from IDB using `post.id` (local)
- [ ] `res.json()` parse removed from the sync loop
- [ ] `pnpm build` succeeds
- [ ] `pnpm test` passes all unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)