### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11.5.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm exec tsc --noEmit
+
+      - name: Unit tests
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` that runs on every push to `master` and every PR targeting `master`
- Steps: `tsc --noEmit` → `pnpm test` (vitest, 14 unit tests) → `pnpm build`
- Uses Node 22 + pnpm 11.5.0 (matching `packageManager` field in `package.json`)

Once merged, all open PRs will automatically get CI checks.

## Test plan

- [ ] Workflow file present at `.github/workflows/ci.yml`
- [ ] CI run on this PR passes all three steps (type check, unit tests, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)