### PR TITLE
Fix inverted logic in askForNotificationPermission

### DIFF
--- a/src/js/app.ts
+++ b/src/js/app.ts
@@ -103,7 +103,7 @@ async function askForNotificationPermission() {
   const permission = await Notification.requestPermission();
   if (permission === 'granted') {
     enableNotificationsButtons.forEach(btn => {
-      (btn as HTMLElement).style.display = 'inline-block';
+      (btn as HTMLElement).style.display = 'none';
     });
     configurePushSub();
   }


### PR DESCRIPTION
## Summary

The Enable Notifications button was staying visible after the user granted notification permission because the button's `display` was being set to `'inline-block'` (showing it) instead of `'none'` (hiding it) in the `askForNotificationPermission` callback.

Changed `style.display = 'inline-block'` to `style.display = 'none'` so the button is correctly hidden once the permission has been granted.

Closes #56