### PR TITLE
Reset picture field in clearPostForm

### DIFF
--- a/src/js/feed.ts
+++ b/src/js/feed.ts
@@ -285,6 +285,8 @@ async function submitPostViaSyncManager() {
 function clearPostForm() {
   titleInput.value = '';
   locationInput.value = '';
+  picture = undefined;
+  imagePicker.value = '';
 }
 
 form.addEventListener('submit', async evt => {


### PR DESCRIPTION
## Summary

`clearPostForm` was only resetting the `titleInput` and `locationInput` fields, but not the `picture` variable or the `imagePicker` file input. This meant that after a successful post, the previous image blob was still held in memory and the file input still showed the old selection, allowing it to be silently resubmitted with the next post.

Added `picture = undefined` and `imagePicker.value = ''` to `clearPostForm` so the image state is fully reset after each submission.

Closes #57