### PR TITLE
fix: guard SyncManager path with active SW check

### DIFF
--- a/src/js/feed.ts
+++ b/src/js/feed.ts
@@ -301,13 +301,16 @@ form.addEventListener('submit', async evt => {
   }
   closeCreatePostModal();
 
-  if ('serviceWorker' in navigator && 'SyncManager' in window) {
+  const swReg = 'serviceWorker' in navigator
+    ? await navigator.serviceWorker.getRegistration()
+    : undefined;
+
+  if (swReg?.active && 'SyncManager' in window) {
     await submitPostViaSyncManager();
-    clearPostForm();
   } else {
     await submitPost();
-    clearPostForm();
   }
+  clearPostForm();
 });
 
 if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary

- `navigator.serviceWorker.ready` never resolves in dev (no SW registered), causing `submitPostViaSyncManager` to hang indefinitely and `clearPostForm` to never run
- Replace the `'serviceWorker' in navigator && 'SyncManager' in window` capability heuristic with `navigator.serviceWorker.getRegistration()` — which resolves immediately — and only use the SyncManager path when a SW is actually active
- Consolidate `clearPostForm()` to a single unconditional call after both paths (removing the duplicated calls inside each branch)

Closes #60

## Test plan

- [ ] In dev (`pnpm dev`, no SW registered): submit a post → form fields and image picker clear immediately; no hang
- [ ] Verify submitted post data (title, location, image) is captured correctly before `clearPostForm` runs
- [ ] In production build (SW active): SyncManager path still taken; toast shown; form clears after sync registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)