### PR TITLE
test: add unit coverage for clearPostForm and SW routing

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -8,6 +8,12 @@
       "port": 1338
     },
     {
+      "name": "Frontend (Production Preview)",
+      "runtimeExecutable": "cmd",
+      "runtimeArgs": ["/c", "node_modules\\.bin\\vite.CMD", "preview", "--port", "1339"],
+      "port": 1339
+    },
+    {
       "name": "iOS WebKit Debug Proxy",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["run", "remote-ios"],

--- a/src/js/feed.test.ts
+++ b/src/js/feed.test.ts
@@ -103,7 +103,7 @@ describe('form submit — SW routing', () => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
     // Undo any navigator.serviceWorker injection
-    Object.defineProperty(global.navigator, 'serviceWorker', {
+    Object.defineProperty(globalThis.navigator, 'serviceWorker', {
       value: undefined,
       configurable: true,
       writable: true,
@@ -129,7 +129,7 @@ describe('form submit — SW routing', () => {
   it('calls sync.register (SyncManager path) when SW is active', async () => {
     const registerSpy = vi.fn().mockResolvedValue(undefined);
 
-    Object.defineProperty(global.navigator, 'serviceWorker', {
+    Object.defineProperty(globalThis.navigator, 'serviceWorker', {
       value: {
         getRegistration: vi.fn().mockResolvedValue({ active: { state: 'activated' } }),
         ready: Promise.resolve({ sync: { register: registerSpy } }),

--- a/src/js/feed.test.ts
+++ b/src/js/feed.test.ts
@@ -1,0 +1,150 @@
+// fake-indexeddb/auto must be imported before feed.ts so IDB is patched at module load
+import 'fake-indexeddb/auto';
+import { vi, describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+
+const FEED_HTML = `
+  <button id="share-image-button"></button>
+  <div id="create-post">
+    <video id="player"></video>
+    <canvas id="canvas"></canvas>
+    <button id="capture-btn" type="button"></button>
+    <div id="pick-image">
+      <input type="file" id="image-picker">
+    </div>
+    <form>
+      <input id="title" type="text">
+      <input id="location" type="text">
+      <button id="location-btn" type="button">Get Location</button>
+      <div id="location-loader"></div>
+      <button id="post-btn" type="submit">Post!</button>
+      <button id="close-create-post-modal-btn" type="button">Close</button>
+    </form>
+  </div>
+  <div id="shared-moments"></div>
+  <div id="confirmation-toast"><span id="toast-message"></span></div>
+`;
+
+let clearPostForm: () => void;
+
+beforeAll(async () => {
+  document.body.innerHTML = FEED_HTML;
+  // Stub fetch before module import — loadDataAndUpdate() fires at module level
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 503 })));
+  const mod = await import('./feed.js');
+  clearPostForm = (mod as any).clearPostForm;
+  vi.unstubAllGlobals();
+});
+
+// Injects a File into the imagePicker and waits for the async change handler to set `picture`.
+// Uses Object.defineProperty because jsdom does not expose DataTransfer as a global.
+async function loadPicture(): Promise<void> {
+  const picker = document.getElementById('image-picker') as HTMLInputElement;
+  const file = new File(['x'], 'photo.jpg', { type: 'image/jpeg' });
+  const fileList = Object.assign([file], { item: (i: number) => fileList[i] ?? null });
+  Object.defineProperty(picker, 'files', { get: () => fileList, configurable: true });
+  picker.dispatchEvent(new Event('change', { bubbles: true }));
+  await new Promise(r => setTimeout(r, 300));
+}
+
+// ─── clearPostForm ────────────────────────────────────────────────────────────
+
+describe('clearPostForm', () => {
+  beforeEach(() => {
+    (document.getElementById('title') as HTMLInputElement).value = 'My Vacation';
+    (document.getElementById('location') as HTMLInputElement).value = 'Paris, FR';
+  });
+
+  it('clears titleInput', () => {
+    clearPostForm();
+    expect((document.getElementById('title') as HTMLInputElement).value).toBe('');
+  });
+
+  it('clears locationInput', () => {
+    clearPostForm();
+    expect((document.getElementById('location') as HTMLInputElement).value).toBe('');
+  });
+
+  it('clears imagePicker', () => {
+    clearPostForm();
+    expect((document.getElementById('image-picker') as HTMLInputElement).value).toBe('');
+  });
+
+  it('resets picture — subsequent submit without a new image is rejected', async () => {
+    await loadPicture();
+    clearPostForm();
+
+    // Refill text fields but do NOT pick a new image
+    (document.getElementById('title') as HTMLInputElement).value = 'Second Post';
+    (document.getElementById('location') as HTMLInputElement).value = 'Berlin, DE';
+
+    let alerted = '';
+    vi.stubGlobal('alert', (msg: string) => { alerted = msg; });
+    document.querySelector('form')!.dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true })
+    );
+    await new Promise(r => setTimeout(r, 100));
+
+    expect(alerted).toBe('Please capture or pick an image!');
+    vi.unstubAllGlobals();
+  });
+});
+
+// ─── Form submit — SW routing ─────────────────────────────────────────────────
+
+describe('form submit — SW routing', () => {
+  beforeEach(async () => {
+    await loadPicture();
+    (document.getElementById('title') as HTMLInputElement).value = 'Test Post';
+    (document.getElementById('location') as HTMLInputElement).value = 'Tokyo, JP';
+    vi.stubGlobal('alert', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    // Undo any navigator.serviceWorker injection
+    Object.defineProperty(global.navigator, 'serviceWorker', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('calls fetch (submitPost path) when no active SW registration', async () => {
+    // jsdom has no serviceWorker by default → swReg is undefined → submitPost path
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    document.querySelector('form')!.dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true })
+    );
+    await new Promise(r => setTimeout(r, 500));
+
+    const postCall = fetchSpy.mock.calls.find(c =>
+      String(c[0]).includes('cloudfunctions.net')
+    );
+    expect(postCall).toBeDefined();
+  });
+
+  it('calls sync.register (SyncManager path) when SW is active', async () => {
+    const registerSpy = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(global.navigator, 'serviceWorker', {
+      value: {
+        getRegistration: vi.fn().mockResolvedValue({ active: { state: 'activated' } }),
+        ready: Promise.resolve({ sync: { register: registerSpy } }),
+        addEventListener: vi.fn(),
+      },
+      configurable: true,
+      writable: true,
+    });
+    vi.stubGlobal('SyncManager', class {});
+
+    document.querySelector('form')!.dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true })
+    );
+    await new Promise(r => setTimeout(r, 500));
+
+    expect(registerSpy).toHaveBeenCalledWith('sync-new-posts');
+  });
+});

--- a/src/js/feed.ts
+++ b/src/js/feed.ts
@@ -282,7 +282,7 @@ async function submitPostViaSyncManager() {
   }
 }
 
-function clearPostForm() {
+export function clearPostForm() {
   titleInput.value = '';
   locationInput.value = '';
   picture = undefined;

--- a/src/js/utils.test.ts
+++ b/src/js/utils.test.ts
@@ -133,3 +133,38 @@ describe('IDB CRUD (posts store)', () => {
     expect(afterDelete).toHaveLength(0);
   });
 });
+
+// ─── IDB CRUD (sync-posts store) ──────────────────────────────────────────────
+
+describe('IDB CRUD (sync-posts store)', () => {
+  beforeEach(async () => {
+    await deleteItems('sync-posts');
+  });
+
+  it('writeItem stores a pending post retrievable by getItems', async () => {
+    await writeItem('sync-posts', { id: 's1', title: 'Pending', location: 'NYC' });
+    const items = await getItems('sync-posts');
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ id: 's1', title: 'Pending' });
+  });
+
+  it('getItem returns undefined for a non-existent sync-post id', async () => {
+    expect(await getItem('sync-posts', 'no-such-id')).toBeUndefined();
+  });
+
+  it('deleteItem removes only the targeted sync-post', async () => {
+    await writeItem('sync-posts', { id: 's1', title: 'Keep' });
+    await writeItem('sync-posts', { id: 's2', title: 'Remove' });
+    await deleteItem('sync-posts', 's2');
+    const items = await getItems('sync-posts');
+    expect(items).toHaveLength(1);
+    expect((items[0] as { id: string }).id).toBe('s1');
+  });
+
+  it('deleteItems clears all pending sync-posts', async () => {
+    await writeItem('sync-posts', { id: 's1', title: 'A' });
+    await writeItem('sync-posts', { id: 's2', title: 'B' });
+    await deleteItems('sync-posts');
+    expect(await getItems('sync-posts')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- New `feed.test.ts` — covers the two recent bug fixes end-to-end at the unit level:
  - `clearPostForm` clears all four fields: `titleInput`, `locationInput`, `imagePicker`, and `picture` (the last verified indirectly — a subsequent submit without a new image is blocked by the `!picture` guard)
  - Form submit takes the `submitPost` (direct-fetch) path when `getRegistration()` returns no active SW
  - Form submit takes the SyncManager path (`sync.register('sync-new-posts')` called) when SW is active
- `utils.test.ts` — adds IDB CRUD coverage for the `sync-posts` store, which `submitPostViaSyncManager` writes to but had no dedicated tests
- `feed.ts` — exports `clearPostForm` so it can be directly imported by tests
- `.claude/launch.json` — adds a production-preview entry (port 1339) used during manual verification

**Before → After:** 14 tests → 24 tests (+10)

## Test plan

- [ ] `pnpm test` passes — all 24 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)