### PR TITLE
Make VAPID key and Firebase coordinates configurable via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# ── Frontend configuration (Vite) ────────────────────────────────────────────
+# Copy this file to `.env` and fill in your own Firebase project's coordinates.
+# Everything here is exposed to the browser at build time and is NOT secret
+# (the VAPID *public* key and Firebase URLs are all client-visible by design).
+# Leaving a value blank falls back to the original `pwagram-439bb` project.
+
+# VAPID public key for Web Push — the public pair of the functions'
+# VAPID_PRIVATE_KEY. Generate a pair with: npx web-push generate-vapid-keys
+VITE_VAPID_PUBLIC_KEY=
+
+# Realtime Database base URL, e.g. https://your-project.firebaseio.com
+VITE_FIREBASE_DATABASE_URL=
+
+# Cloud Functions base URL, e.g. https://us-central1-your-project.cloudfunctions.net
+VITE_FIREBASE_FUNCTIONS_URL=
+
+# Note: Cloud Functions configuration lives separately in functions/.env
+# (see functions/.env.example).

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,14 @@ node_modules
 dist
 functions/pwagram-fb-key.json
 
+# Local environment config (keep .env.example tracked)
+.env
+.env.*
+!.env.example
+functions/.env
+functions/.env.*
+!functions/.env.example
+
 # Test output
 test-results/
 playwright-report/

--- a/README.MD
+++ b/README.MD
@@ -9,3 +9,19 @@ You need [Node.js](https://nodejs.org) and [pnpm](https://pnpm.io) installed on 
 Once Node.js and pnpm are installed, open your command prompt or terminal and **navigate into this project folder**. There, run `pnpm install` to install all required dependencies.
 
 Finally, run `pnpm dev` to start the development server and visit [localhost:1338](http://localhost:1338) to see the running application.
+
+# Configuration
+
+The app ships with sensible defaults pointing at the original `pwagram-439bb`
+Firebase project, so it runs without any setup. To point a fork at your own
+Firebase backend, override the coordinates via environment variables — none of
+these are secrets except `VAPID_PRIVATE_KEY`:
+
+- **Frontend** — copy `.env.example` to `.env` and set `VITE_VAPID_PUBLIC_KEY`,
+  `VITE_FIREBASE_DATABASE_URL`, and `VITE_FIREBASE_FUNCTIONS_URL`. Vite reads
+  these at build time.
+- **Cloud Functions** — copy `functions/.env.example` to `functions/.env` and
+  set the VAPID key pair and Firebase project coordinates. The Firebase CLI
+  loads this file automatically.
+
+Generate a VAPID key pair with `npx web-push generate-vapid-keys`.

--- a/functions/.env.example
+++ b/functions/.env.example
@@ -1,0 +1,17 @@
+# ── Cloud Functions configuration ────────────────────────────────────────────
+# Copy this file to `functions/.env`. The Firebase CLI loads it automatically
+# at deploy/emulate time. VAPID_PRIVATE_KEY is the only true secret here — keep
+# the real value out of source control.
+
+# Web Push (VAPID) key pair. Generate with: npx web-push generate-vapid-keys
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+# Contact subject sent with push notifications (mailto: or https: URL)
+VAPID_SUBJECT=mailto:you@example.com
+
+# Firebase project coordinates. Leaving these blank falls back to the original
+# `pwagram-439bb` project; databaseURL/storage bucket are derived from the
+# project ID when not set explicitly.
+FIREBASE_PROJECT_ID=
+FIREBASE_DATABASE_URL=
+FIREBASE_STORAGE_BUCKET=

--- a/functions/index.js
+++ b/functions/index.js
@@ -11,14 +11,27 @@ const { Storage } = require("@google-cloud/storage");
 
 const serviceAccount = require("./pwagram-fb-key.json");
 
+// Firebase coordinates — overridable via env (e.g. functions/.env, see
+// .env.example) so a fork can target its own project. Defaults preserve the
+// original `pwagram-439bb` backend. None of these are secrets.
+const PROJECT_ID = process.env.FIREBASE_PROJECT_ID || "pwagram-439bb";
+const DATABASE_URL =
+  process.env.FIREBASE_DATABASE_URL || `https://${PROJECT_ID}.firebaseio.com/`;
+const STORAGE_BUCKET =
+  process.env.FIREBASE_STORAGE_BUCKET || `${PROJECT_ID}.appspot.com`;
+// VAPID public key is the (non-secret) pair of VAPID_PRIVATE_KEY.
+const VAPID_PUBLIC_KEY =
+  process.env.VAPID_PUBLIC_KEY ||
+  "BH1lo34DNnIy__lc7nzIMyDr2tBmGqqoRThEoRzoj2GehQ8Yg4_X2JvkHfX06Vbqxjys6I0fz2mGLu2nkC45S5o";
+
 const storage = new Storage({
-  projectId: "pwagram-439bb",
+  projectId: PROJECT_ID,
   keyFilename: "pwagram-fb-key.json"
 });
 
 admin.initializeApp({
   credential: admin.credential.cert(serviceAccount),
-  databaseURL: "https://pwagram-439bb.firebaseio.com/"
+  databaseURL: DATABASE_URL
 });
 
 // Parse a multipart upload from a Cloud Function request, waiting for all
@@ -72,7 +85,7 @@ exports.storePostData = functions.https.onRequest((request, response) => {
         return response.status(400).json({ error: "No file uploaded" });
       }
 
-      const bucket = storage.bucket("pwagram-439bb.appspot.com");
+      const bucket = storage.bucket(STORAGE_BUCKET);
       let uploadedFile;
       try {
         [uploadedFile] = await bucket.upload(upload.file, {
@@ -106,8 +119,8 @@ exports.storePostData = functions.https.onRequest((request, response) => {
         });
 
       webpush.setVapidDetails(
-        "mailto:bushidocodes@gmail.com",
-        "BH1lo34DNnIy__lc7nzIMyDr2tBmGqqoRThEoRzoj2GehQ8Yg4_X2JvkHfX06Vbqxjys6I0fz2mGLu2nkC45S5o",
+        process.env.VAPID_SUBJECT || "mailto:bushidocodes@gmail.com",
+        VAPID_PUBLIC_KEY,
         process.env.VAPID_PRIVATE_KEY
       );
 

--- a/src/js/app.ts
+++ b/src/js/app.ts
@@ -1,5 +1,6 @@
 import '../css/main.css';
 import { urlBase64ToUint8Array } from './utils.js';
+import { VAPID_PUBLIC_KEY, SUBSCRIPTIONS_URL } from './config.js';
 
 interface BeforeInstallPromptEvent extends Event {
   prompt(): Promise<void>;
@@ -76,14 +77,12 @@ async function configurePushSub() {
     const existingSub = await sw.pushManager.getSubscription();
     if (existingSub !== null) return;
 
-    const VAPID_PUBLIC_KEY =
-      'BH1lo34DNnIy__lc7nzIMyDr2tBmGqqoRThEoRzoj2GehQ8Yg4_X2JvkHfX06Vbqxjys6I0fz2mGLu2nkC45S5o';
     const newSub = await sw.pushManager.subscribe({
       userVisibleOnly: true,
       applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY).buffer as ArrayBuffer
     });
     const res = await fetch(
-      'https://pwagram-439bb.firebaseio.com/subscriptions.json',
+      SUBSCRIPTIONS_URL,
       {
         method: 'POST',
         headers: {

--- a/src/js/config.ts
+++ b/src/js/config.ts
@@ -1,0 +1,31 @@
+// Centralized frontend configuration, resolved from Vite environment variables
+// (VITE_*) at build time. None of these values are secrets — the VAPID public
+// key and Firebase coordinates are all client-visible by design. Each falls
+// back to the original `pwagram-439bb` project so the app stays runnable
+// without a `.env` file; set the variables (see `.env.example`) to point a fork
+// at your own Firebase backend.
+
+const env = import.meta.env;
+
+const stripTrailingSlash = (url: string): string => url.replace(/\/+$/, '');
+
+// Use `||` (not `??`) so a blank value in `.env` falls back to the default
+// rather than producing an empty key / broken URL.
+export const VAPID_PUBLIC_KEY =
+  env.VITE_VAPID_PUBLIC_KEY ||
+  'BH1lo34DNnIy__lc7nzIMyDr2tBmGqqoRThEoRzoj2GehQ8Yg4_X2JvkHfX06Vbqxjys6I0fz2mGLu2nkC45S5o';
+
+// Realtime Database base URL, e.g. https://your-project.firebaseio.com
+export const FIREBASE_DATABASE_URL = stripTrailingSlash(
+  env.VITE_FIREBASE_DATABASE_URL || 'https://pwagram-439bb.firebaseio.com'
+);
+
+// Cloud Functions base URL, e.g. https://us-central1-your-project.cloudfunctions.net
+export const FIREBASE_FUNCTIONS_URL = stripTrailingSlash(
+  env.VITE_FIREBASE_FUNCTIONS_URL ||
+    'https://us-central1-pwagram-439bb.cloudfunctions.net'
+);
+
+export const POSTS_URL = `${FIREBASE_DATABASE_URL}/posts.json`;
+export const SUBSCRIPTIONS_URL = `${FIREBASE_DATABASE_URL}/subscriptions.json`;
+export const STORE_POST_DATA_URL = `${FIREBASE_FUNCTIONS_URL}/storePostData`;

--- a/src/js/feed.ts
+++ b/src/js/feed.ts
@@ -1,4 +1,5 @@
 import { getItems, writeItem, dataURItoBlob } from './utils.js';
+import { POSTS_URL, STORE_POST_DATA_URL } from './config.js';
 
 declare global {
   interface Window {
@@ -217,10 +218,9 @@ function createCards(cards: PostCard[]) {
 // Cache-then-network: start both fetches in parallel; IDB renders first if
 // the network hasn't responded yet, then network overwrites with fresher data.
 export function loadDataAndUpdate() {
-  const url = 'https://pwagram-439bb.firebaseio.com/posts.json';
   let networkDataReceived = false;
 
-  fetch(url)
+  fetch(POSTS_URL)
     .then(res => (res.ok ? res.json() : null))
     .then((data: Record<string, PostCard> | null) => {
       if (!data) return;
@@ -253,10 +253,7 @@ async function submitPost() {
   postData.append('rawLocationLng', String(fetchedLocation.lng));
 
   try {
-    await fetch(
-      'https://us-central1-pwagram-439bb.cloudfunctions.net/storePostData',
-      { method: 'POST', body: postData }
-    );
+    await fetch(STORE_POST_DATA_URL, { method: 'POST', body: postData });
     clearPostForm();
     loadDataAndUpdate();
   } catch {

--- a/src/js/vite-env.d.ts
+++ b/src/js/vite-env.d.ts
@@ -1,0 +1,10 @@
+interface ImportMetaEnv {
+  readonly VITE_VAPID_PUBLIC_KEY?: string;
+  readonly VITE_FIREBASE_DATABASE_URL?: string;
+  readonly VITE_FIREBASE_FUNCTIONS_URL?: string;
+  readonly [key: string]: string | boolean | undefined;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/sw.js
+++ b/src/sw.js
@@ -4,6 +4,7 @@ import { CacheFirst, NetworkFirst } from 'workbox-strategies';
 import { ExpirationPlugin } from 'workbox-expiration';
 import { CacheableResponsePlugin } from 'workbox-cacheable-response';
 import { openDB } from 'idb';
+import { POSTS_URL, STORE_POST_DATA_URL } from './js/config.js';
 
 // Injected by vite-plugin-pwa at build time ([] in dev)
 precacheAndRoute(self.__WB_MANIFEST);
@@ -39,8 +40,6 @@ registerRoute(
 
 // Firebase posts — network first; on success, sync result into IDB so the
 // browser-side cache-then-network pattern in feed.js sees fresh data.
-const POSTS_URL = 'https://pwagram-439bb.firebaseio.com/posts.json';
-
 registerRoute(
   ({ url }) => url.href === POSTS_URL,
   async ({ event }) => {
@@ -74,8 +73,7 @@ setCatchHandler(async ({ event }) => {
 
 // ─── Background Sync ─────────────────────────────────────────────────────────
 
-const UPLOAD_POSTS_URL =
-  'https://us-central1-pwagram-439bb.cloudfunctions.net/storePostData';
+const UPLOAD_POSTS_URL = STORE_POST_DATA_URL;
 
 async function syncNewPosts() {
   const db = await dbPromise;


### PR DESCRIPTION
## Summary

Closes #64. The VAPID public key and Firebase project coordinates (project ID, Realtime Database URL, storage bucket, Cloud Functions URL) were hardcoded across the frontend and Cloud Functions. None are secrets, but hardcoding them coupled the repo to the `pwagram-439bb` project and meant anyone forking would push to the original backend until they hunted down every literal. There was also no documented way to configure a different Firebase project.

## What changed

- **New `src/js/config.ts`** — single source of truth for the frontend. Reads `VITE_*` env vars, derives `POSTS_URL` / `SUBSCRIPTIONS_URL` / `STORE_POST_DATA_URL` from base URLs (with trailing-slash normalization), and falls back to the original `pwagram-439bb` values. Imported by `app.ts`, `feed.ts`, **and** `sw.js`.
- **`functions/index.js`** — `FIREBASE_PROJECT_ID`, `FIREBASE_DATABASE_URL`, `FIREBASE_STORAGE_BUCKET`, `VAPID_PUBLIC_KEY`, and `VAPID_SUBJECT` now resolve from `process.env` with fallbacks (the Firebase CLI auto-loads `functions/.env`).
- **`.env.example`** (frontend) and **`functions/.env.example`** documenting every variable, plus a README **Configuration** section.
- **`src/js/vite-env.d.ts`** typing the `VITE_*` vars; **`.gitignore`** rules for `.env` files (keeping `.env.example` tracked).

## Design notes

- **Defaults preserved, not required.** Every value falls back to the existing `pwagram-439bb` coordinates, so the app still runs with no `.env` and the existing unit/e2e tests (which assert on `firebaseio.com` / `cloudfunctions.net`) stay green. This matches the issue's framing as a low-priority configurability change, not a breaking one.
- **`||` not `??`.** A blank value in a copied-but-unfilled `.env` falls back to the default rather than producing an empty key / broken URL.
- The `keyFilename: "pwagram-fb-key.json"` reference (a gitignored local credential file, not a coordinate) was intentionally left as-is.

## Verification

- `pnpm typecheck` — pass
- `pnpm test` — 29/29 pass
- `pnpm build` — main bundle + injectManifest service worker build clean
- Inspected `dist/`: defaults inline when env is unset; **overrides win** when set (built with a custom `VITE_FIREBASE_DATABASE_URL` → custom host inlined in both the app bundle and the SW); **blank values fall back** to defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
