### PR TITLE
fix: resolve CodeQL incomplete URL substring sanitization alert

### DIFF
--- a/src/js/feed.test.ts
+++ b/src/js/feed.test.ts
@@ -125,9 +125,14 @@ describe('form submit — SW routing', () => {
     );
     await new Promise(r => setTimeout(r, 500));
 
-    const postCall = fetchSpy.mock.calls.find(c =>
-      String(c[0]).includes('cloudfunctions.net')
-    );
+    const postCall = fetchSpy.mock.calls.find(c => {
+      try {
+        const { hostname } = new URL(String(c[0]));
+        return hostname === 'cloudfunctions.net' || hostname.endsWith('.cloudfunctions.net');
+      } catch {
+        return false;
+      }
+    });
     expect(postCall).toBeDefined();
   });
 


### PR DESCRIPTION
## Summary

- Fixes CodeQL alert [js/incomplete-url-substring-sanitization #1](https://github.com/bushidocodes/instagram-clone/security/code-scanning/1)
- Replaces `String(c[0]).includes('cloudfunctions.net')` in `feed.test.ts` with a proper `URL`-parsed hostname check
- The new check matches `hostname === 'cloudfunctions.net'` or `hostname.endsWith('.cloudfunctions.net')`, so only actual Cloud Functions hostnames match — not URLs with the substring embedded in the path or query string

## What changed

`src/js/feed.test.ts:129` — the test that verifies a `fetch` POST goes to the Cloud Functions endpoint was using a substring check. CodeQL flagged this as `js/incomplete-url-substring-sanitization` (CWE-020, high severity) because a URL like `http://evil.com/cloudfunctions.net` would also pass the check.

The fix wraps the check in a `try/catch` (to handle non-URL arguments gracefully) and compares the parsed `hostname` instead.

## Test plan

- [x] All 11 tests in `feed.test.ts` pass (`npm test -- --run src/js/feed.test.ts`)
- [x] CodeQL rule `js/incomplete-url-substring-sanitization` no longer applies to the fixed line

🤖 Generated with [Claude Code](https://claude.com/claude-code)